### PR TITLE
setup contacts to have relationship

### DIFF
--- a/app/assets/javascripts/relationships.coffee
+++ b/app/assets/javascripts/relationships.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,48 @@
+class RelationshipsController < ApplicationController
+  before_action :set_company_and_contact, only: [:index, :new, :create, :destroy]
+
+  def index
+    @relationships = Relationship.where("contact_id = :contact OR relation_id = :contact", contact: @contact)
+  end
+
+  def new
+    @relationship = @contact.relationships.build
+  end
+
+  def create
+    relation = @company.contacts.find_by(id: relationship_params[:relation_id])
+    @relationship = relation ? @contact.relationships.build(relation_id: relation.id) : @contact.relationships.build
+
+    respond_to do |format|
+      if @relationship.save
+        format.html { redirect_to company_contact_relationships_path(@company, @contact), notice: 'Relationship was successfully created.' }
+        format.json { render :show, status: :created, location: @relationship }
+      else
+        format.html { render :new }
+        format.json { render json: @relationship.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    relationships = Relationship.where("contact_id = :contact OR relation_id = :contact", contact: @contact)
+    @relationship = relationships.find(params[:id])
+
+    @relationship.destroy
+    respond_to do |format|
+      format.html { redirect_to company_contact_relationships_url(@company, @contact), notice: 'Relationship was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    def set_company_and_contact
+      @company = Company.includes(:contacts).where(contacts: {id: params[:contact_id]}).find(params[:company_id])
+      @contact = @company.contacts.last
+    end
+
+    def relationship_params
+      params.require(:relationship).permit(:contact_id, :relation_id)
+    end
+end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,9 @@
 class Contact < ApplicationRecord
   belongs_to :company
+  has_many :relationships
+  has_many :relations, through: :relationships, dependent: :destroy
+  has_many :inverse_relationships, class_name: 'Relationship', foreign_key: 'relation_id'
+  has_many :inverse_relations, through: :inverse_relationships, source: :contact, dependent: :destroy
+
   validates :first_name, :surname, presence: true
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,6 @@
+class Relationship < ApplicationRecord
+  belongs_to :contact
+  belongs_to :relation, class_name: 'Contact'
+
+  validates :contact_id, :relation_id, presence: true
+end

--- a/app/views/relationships/_form.html.erb
+++ b/app/views/relationships/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for([@company, @contact, relationship]) do |f| %>
+  <% if relationship.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(relationship.errors.count, "error") %> prohibited this relationship from being saved:</h2>
+
+      <ul>
+      <% relationship.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :relation_id %>
+    <%= f.number_field :relation_id %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/relationships/_relationship.json.jbuilder
+++ b/app/views/relationships/_relationship.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! relationship, :id, :contact_id, :relation_id, :created_at, :updated_at
+json.url relationship_url(relationship, format: :json)

--- a/app/views/relationships/index.html.erb
+++ b/app/views/relationships/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Relationships</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Contact</th>
+      <th>Relation</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @relationships.each do |relationship| %>
+      <tr>
+        <td><%= relationship.contact_id %></td>
+        <td><%= relationship.relation_id %></td>
+        <td><%= link_to 'Destroy', company_contact_relationship_path(@company, @contact, relationship), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+
+
+<%= link_to 'New Relationship', new_company_contact_relationship_path(@company, @contact) %>

--- a/app/views/relationships/index.json.jbuilder
+++ b/app/views/relationships/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @relationships, partial: 'relationships/relationship', as: :relationship

--- a/app/views/relationships/new.html.erb
+++ b/app/views/relationships/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Relationship</h1>
+
+<%= render 'form', relationship: @relationship %>
+
+<%= link_to 'Back', company_contact_relationships_path(@company, @contact) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
+
   root "companies#index"
   resources :companies do
-    resources :contacts
+    resources :contacts do
+      resources :relationships, only: [:index, :new, :create, :destroy]
+    end
   end
 end

--- a/db/migrate/20170310085355_create_relationships.rb
+++ b/db/migrate/20170310085355_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[5.0]
+  def change
+    create_table :relationships do |t|
+      t.integer :contact_id
+      t.integer :relation_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310060325) do
+ActiveRecord::Schema.define(version: 20170310085355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 20170310060325) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["company_id"], name: "index_contacts_on_company_id", using: :btree
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer  "contact_id"
+    t.integer  "relation_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   add_foreign_key "contacts", "companies"

--- a/spec/controllers/relationships_controller_spec.rb
+++ b/spec/controllers/relationships_controller_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe RelationshipsController, type: :controller do
+  let(:company_with_contacts) { FactoryGirl.create(:company_with_contacts) }
+  let(:company) { company_with_contacts }
+  let(:contact) { company_with_contacts.contacts[0] }
+  let(:relation) { company_with_contacts.contacts[1] }
+  let(:another_company) { FactoryGirl.create(:company_with_contacts, name: "Another Company") }
+  let(:another_company_contact) { another_company.contacts[0] }
+
+  let(:valid_attributes) {
+    { relation_id: relation.id }
+  }
+
+  let(:invalid_attributes) {
+    { relation_id: "freddo" }
+  }
+
+  let(:valid_session) { {} }
+
+  describe "GET #index" do
+    it "assigns all relationships as @relationships" do
+      relationship = contact.relationships.create! valid_attributes
+      get :index, params: { company_id: company.id, contact_id: contact.id }, session: valid_session
+      expect(assigns(:relationships)).to eq([relationship])
+    end
+  end
+
+  describe "GET #new" do
+    it "assigns a new relationship as @relationship" do
+      get :new, params: { company_id: company.id, contact_id: contact.id }, session: valid_session
+      expect(assigns(:relationship)).to be_a_new(Relationship)
+    end
+  end
+
+  describe "POST #create" do
+    context "with valid params" do
+      it "creates a new Relationship" do
+        expect {
+          post :create, params: { relationship: valid_attributes, company_id: company.id, contact_id: contact.id }, session: valid_session
+        }.to change(Relationship, :count).by(1)
+      end
+
+      it "assigns a newly created relationship as @relationship" do
+        post :create, params: {relationship: valid_attributes, company_id: company.id, contact_id: contact.id}, session: valid_session
+        expect(assigns(:relationship)).to be_a(Relationship)
+        expect(assigns(:relationship)).to be_persisted
+      end
+
+      it "redirects to the relationships index for the contact" do
+        post :create, params: {relationship: valid_attributes, company_id: company.id, contact_id: contact.id}, session: valid_session
+        expect(response).to redirect_to company_contact_relationships_path(company.id, contact.id)
+      end
+    end
+
+    context "with invalid params" do
+      it "assigns a newly created but unsaved relationship as @relationship" do
+        post :create, params: {relationship: invalid_attributes, company_id: company.id, contact_id: contact.id}, session: valid_session
+        expect(assigns(:relationship)).to be_a_new(Relationship)
+      end
+
+      it "doesn't allow creating a relationship with a contact from another company" do
+        post :create, params: {relationship: {relation_id: another_company_contact.id}, company_id: company.id, contact_id: contact.id}, session: valid_session
+        expect(assigns(:relationship)).to be_a_new(Relationship)
+        expect(response).to render_template("new")
+      end
+
+      it "re-renders the 'new' template" do
+        post :create, params: {relationship: invalid_attributes, company_id: company.id, contact_id: contact.id}, session: valid_session
+        expect(response).to render_template("new")
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it "destroys the requested relationship when made by the contact" do
+      relationship = contact.relationships.create! valid_attributes
+      expect {
+        delete :destroy, params: {id: relationship.to_param, company_id: company.id, contact_id: contact.id}, session: valid_session
+      }.to change(Relationship, :count).by(-1)
+    end
+
+    it "destroys the requested relationship when made by another contact (inverse)" do
+      relationship = contact.relationships.create! valid_attributes
+      expect {
+        delete :destroy, params: {id: relationship.to_param, company_id: company_with_contacts.id, contact_id: relation.id}, session: valid_session
+      }.to change(Relationship, :count).by(-1)
+    end
+
+    it "redirects to the relationships list" do
+      relationship = contact.relationships.create! valid_attributes
+      delete :destroy, params: {id: relationship.to_param, company_id: company_with_contacts.id, contact_id: company_with_contacts.contacts[0].id}, session: valid_session
+      expect(response).to redirect_to company_contact_relationships_path(company, contact)
+    end
+  end
+
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,20 @@
 FactoryGirl.define do
   factory :company do
     name "Hogwarts"
+
+    factory :company_with_contacts do
+      transient do
+        contacts_count 3
+      end
+
+      after(:create) do |company, evaluator|
+        create_list(:contact, evaluator.contacts_count, company: company)
+      end
+    end
+  end
+
+  factory :contact do
+    sequence(:first_name) { |n| "first-#{n}"}
+    sequence(:surname) { |n| "surname-#{n}" }
   end
 end

--- a/spec/helpers/relationships_helper_spec.rb
+++ b/spec/helpers/relationships_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RelationshipsHelper. For example:
+#
+# describe RelationshipsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RelationshipsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/relationships_spec.rb
+++ b/spec/requests/relationships_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Relationships", type: :request do
+  describe "GET /relationships" do
+    xit "works! (now write some real specs)" do
+      get relationships_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/routing/relationships_routing_spec.rb
+++ b/spec/routing/relationships_routing_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe RelationshipsController, type: :routing do
+  describe "routing" do
+
+    it "routes to #index" do
+      expect(:get => "/companies/1/contacts/1/relationships").to route_to("relationships#index", company_id: "1", contact_id: "1")
+    end
+
+    it "routes to #new" do
+      expect(:get => "/companies/1/contacts/1/relationships/new").to route_to("relationships#new", company_id: "1", contact_id: "1")
+    end
+
+    it "routes to #create" do
+      expect(:post => "/companies/1/contacts/1/relationships").to route_to("relationships#create", company_id: "1", contact_id: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(:delete => "/companies/1/contacts/1/relationships/1").to route_to("relationships#destroy", company_id: "1", contact_id: "1", id: "1")
+    end
+
+  end
+end

--- a/spec/views/relationships/edit.html.erb_spec.rb
+++ b/spec/views/relationships/edit.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "relationships/edit", type: :view do
+  before(:each) do
+    @relationship = assign(:relationship, Relationship.create!(
+      :contact_id => 1,
+      :relation_id => 1
+    ))
+  end
+
+  xit "renders the edit relationship form" do
+    render
+
+    assert_select "form[action=?][method=?]", relationship_path(@relationship), "post" do
+
+      assert_select "input#relationship_contact_id[name=?]", "relationship[contact_id]"
+
+      assert_select "input#relationship_relation_id[name=?]", "relationship[relation_id]"
+    end
+  end
+end

--- a/spec/views/relationships/index.html.erb_spec.rb
+++ b/spec/views/relationships/index.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "relationships/index", type: :view do
+  before(:each) do
+    assign(:relationships, [
+      Relationship.create!(
+        :contact_id => 2,
+        :relation_id => 3
+      ),
+      Relationship.create!(
+        :contact_id => 2,
+        :relation_id => 3
+      )
+    ])
+  end
+
+  xit "renders a list of relationships" do
+    render
+    assert_select "tr>td", :text => 2.to_s, :count => 2
+    assert_select "tr>td", :text => 3.to_s, :count => 2
+  end
+end

--- a/spec/views/relationships/new.html.erb_spec.rb
+++ b/spec/views/relationships/new.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "relationships/new", type: :view do
+  before(:each) do
+    assign(:relationship, Relationship.new(
+      :contact_id => 1,
+      :relation_id => 1
+    ))
+  end
+
+  xit "renders new relationship form" do
+    render
+
+    assert_select "form[action=?][method=?]", relationships_path, "post" do
+
+      assert_select "input#relationship_contact_id[name=?]", "relationship[contact_id]"
+
+      assert_select "input#relationship_relation_id[name=?]", "relationship[relation_id]"
+    end
+  end
+end

--- a/spec/views/relationships/show.html.erb_spec.rb
+++ b/spec/views/relationships/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "relationships/show", type: :view do
+  before(:each) do
+    @relationship = assign(:relationship, Relationship.create!(
+      :contact_id => 2,
+      :relation_id => 3
+    ))
+  end
+
+  xit "renders attributes in <p>" do
+    render
+    expect(rendered).to match(/2/)
+    expect(rendered).to match(/3/)
+  end
+end


### PR DESCRIPTION
- contact relationships are self referential using a has_many :through association
- contact relationship look ups include the inverse relationship
- contacts can only create a relationship with contacts from the same company
- contacts can only destroy a relationship they are apart of
- dependent destroy so if a contact is deleted the relationship is also removed from the database